### PR TITLE
Illustrate issue with resolveAlias

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@dcrall/tw-test": "^1.0.0",
     "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "@nuxt/postcss8": "^1.1.3",
     "autoprefixer": "^10.4.2",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <div class="tw-test text-4xl">
+      Hello
+    </div>
     <div>
       <CallToAction />
     </div>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,13 @@ export default defineNuxtConfig({
   buildModules: [
     tailwindModule
   ],
+  css: [],
   tailwindcss: {
+    configPath: '@dcrall/tw-test/tailwind.config.js',
+    cssPath: '@dcrall/tw-test/tailwind.css',
     exposeConfig: true
+  },
+  vite: {
+    logLevel: 'info'
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,6 +49,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using Tailwind CSS from module runtime')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,11 @@
   dependencies:
     mime "^3.0.0"
 
+"@dcrall/tw-test@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcrall/tw-test/-/tw-test-1.0.0.tgz#2850c9c66f902afc8065e87fea9c4894c9fd4477"
+  integrity sha512-/14Zf0DTud9pvGUYTZCN3S8t08lOgfC7qbxViQdvYDL606lgIrXyh4zCNaIMeEMV4nl8QIV3d3joQ/mkVaQqrA==
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"


### PR DESCRIPTION
Use the @dcrall/tw-test package to illustrate the current module's
inability to import a Tailwind stylesheet from a package.

Logging statement added to the else clause that loads the module's
default CSS file shows the package's tailwind.css is not resolved
and is not loaded.