### PR TITLE
Modified module working with @dcrall/tw-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@dcrall/tw-test": "^1.0.0",
     "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "@nuxt/postcss8": "^1.1.3",
     "autoprefixer": "^10.4.2",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <div class="tw-test text-4xl">
+      Hello
+    </div>
     <div>
       <CallToAction />
     </div>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,13 @@ export default defineNuxtConfig({
   buildModules: [
     tailwindModule
   ],
+  css: [],
   tailwindcss: {
+    configPath: '@dcrall/tw-test/tailwind.config.js',
+    cssPath: '@dcrall/tw-test/tailwind.css',
     exposeConfig: true
+  },
+  vite: {
+    logLevel: 'info'
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
+    const cssPath = await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] })
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,6 +49,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using Tailwind CSS from module runtime')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {
   installModule,
   addTemplate,
   addServerMiddleware,
-  resolveAlias,
   requireModule,
   isNuxt2,
   createResolver,
@@ -40,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && resolveAlias(moduleOptions.cssPath)
+    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
@@ -49,7 +48,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
-        logger.info('Using Tailwind CSS from module runtime')
+        logger.info('Using default Tailwind CSS file from runtime/tailwind.css')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {
   installModule,
   addTemplate,
   addServerMiddleware,
-  resolveAlias,
   requireModule,
   isNuxt2,
   createResolver,
@@ -40,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && resolveAlias(moduleOptions.cssPath)
+    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
@@ -49,6 +48,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using default Tailwind CSS file from runtime/tailwind.css')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,11 @@
   dependencies:
     mime "^3.0.0"
 
+"@dcrall/tw-test@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcrall/tw-test/-/tw-test-1.0.0.tgz#2850c9c66f902afc8065e87fea9c4894c9fd4477"
+  integrity sha512-/14Zf0DTud9pvGUYTZCN3S8t08lOgfC7qbxViQdvYDL606lgIrXyh4zCNaIMeEMV4nl8QIV3d3joQ/mkVaQqrA==
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"


### PR DESCRIPTION
In this branch, we use the modified module that uses `resolvePath` for the CSS file. In the following screenshots, we can see that the module finds the stylesheet at `@dcrall/tw-test/tailwind.css` and the first div has the gold background as expected.

![tw-test-working-console](https://user-images.githubusercontent.com/42922/167659999-bc657012-eac1-4c96-a762-6919d88ee2b3.png)

<img width="767" alt="tw-test-working" src="https://user-images.githubusercontent.com/42922/167660106-58416b5b-c4a4-4be5-a355-eb9aff679eca.png">


