### PR TITLE
Alias to assets working with modified module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@dcrall/tw-test": "^1.0.0",
     "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "@nuxt/postcss8": "^1.1.3",
     "autoprefixer": "^10.4.2",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <div class="tw-test text-4xl">
+      Hello
+    </div>
     <div>
       <CallToAction />
     </div>

--- a/playground/assets/tailwind.css
+++ b/playground/assets/tailwind.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .tw-test { @apply p-4 text-ui-gold bg-ui-gray-900; }
+}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,13 @@ export default defineNuxtConfig({
   buildModules: [
     tailwindModule
   ],
+  css: [],
   tailwindcss: {
+    configPath: '@dcrall/tw-test/tailwind.config.js',
+    cssPath: '@dcrall/tw-test/tailwind.css',
     exposeConfig: true
+  },
+  vite: {
+    logLevel: 'info'
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
   css: [],
   tailwindcss: {
     configPath: '@dcrall/tw-test/tailwind.config.js',
-    cssPath: '@dcrall/tw-test/tailwind.css',
+    cssPath: '~/assets/tailwind.css',
     exposeConfig: true
   },
   vite: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,8 @@ export default defineNuxtModule({
     const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
+    logger.info(`CSS path: ${cssPath}`)
+
     // Include CSS file in project css
     if (typeof cssPath === 'string') {
       if (existsSync(cssPath)) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,6 +49,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using Tailwind CSS from module runtime')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {
   installModule,
   addTemplate,
   addServerMiddleware,
-  resolveAlias,
   requireModule,
   isNuxt2,
   createResolver,
@@ -40,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && resolveAlias(moduleOptions.cssPath)
+    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
@@ -49,7 +48,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
-        logger.info('Using Tailwind CSS from module runtime')
+        logger.info('Using default Tailwind CSS file from runtime/tailwind.css')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,11 @@
   dependencies:
     mime "^3.0.0"
 
+"@dcrall/tw-test@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcrall/tw-test/-/tw-test-1.0.0.tgz#2850c9c66f902afc8065e87fea9c4894c9fd4477"
+  integrity sha512-/14Zf0DTud9pvGUYTZCN3S8t08lOgfC7qbxViQdvYDL606lgIrXyh4zCNaIMeEMV4nl8QIV3d3joQ/mkVaQqrA==
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"


### PR DESCRIPTION
Here we show that the modified module will still resolve paths that include stylesheets in the local project. `resolvePath` calls `resolveAlias`, so the standard path still works as expected. The screenshots show the CSS file is loaded from assets, and we see the new black background confirming the modified stylesheet in assets is in effect.

![tw-test-assets-console](https://user-images.githubusercontent.com/42922/167661189-b9c851df-be33-49c0-93c2-b62a5af5514b.png)

<img width="767" alt="tw-test-assets" src="https://user-images.githubusercontent.com/42922/167661238-8b2ee035-ed75-4ff3-8c8d-7f2751a820d6.png">

