### PR TITLE
Tw test assets extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "yarn lint"
   },
   "dependencies": {
+    "@dcrall/tw-test": "^1.0.0",
     "@nuxt/kit": "npm:@nuxt/kit-edge@latest",
     "@nuxt/postcss8": "^1.1.3",
     "autoprefixer": "^10.4.2",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <div class="tw-test text-4xl">
+      Hello
+    </div>
     <div>
       <CallToAction />
     </div>

--- a/playground/assets/tailwind.css
+++ b/playground/assets/tailwind.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer components {
+  .tw-test { @apply p-4 text-ui-gold bg-ui-gray-900; }
+}

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -6,7 +6,13 @@ export default defineNuxtConfig({
   buildModules: [
     tailwindModule
   ],
+  css: [],
   tailwindcss: {
+    configPath: '@dcrall/tw-test/tailwind.config.js',
+    cssPath: '@dcrall/tw-test/tailwind.css',
     exposeConfig: true
+  },
+  vite: {
+    logLevel: 'info'
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
   css: [],
   tailwindcss: {
     configPath: '@dcrall/tw-test/tailwind.config.js',
-    cssPath: '@dcrall/tw-test/tailwind.css',
+    cssPath: '~/assets/tailwind.css',
     exposeConfig: true
   },
   vite: {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
   css: [],
   tailwindcss: {
     configPath: '@dcrall/tw-test/tailwind.config.js',
-    cssPath: '~/assets/tailwind.css',
+    cssPath: '~/assets/tailwind',
     exposeConfig: true
   },
   vite: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,8 @@ export default defineNuxtModule({
     const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
+    logger.info(`CSS path: ${cssPath}`)
+
     // Include CSS file in project css
     if (typeof cssPath === 'string') {
       if (existsSync(cssPath)) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
+    const cssPath = await resolvePath(moduleOptions.cssPath, { extensions: ['.css', '.sass', '.scss', '.less', '.styl'] })
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     logger.info(`CSS path: ${cssPath}`)

--- a/src/module.ts
+++ b/src/module.ts
@@ -49,6 +49,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
+        logger.info('Using Tailwind CSS from module runtime')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,6 @@ import {
   installModule,
   addTemplate,
   addServerMiddleware,
-  resolveAlias,
   requireModule,
   isNuxt2,
   createResolver,
@@ -40,7 +39,7 @@ export default defineNuxtModule({
   }),
   async setup (moduleOptions, nuxt) {
     const configPath = await resolvePath(moduleOptions.configPath)
-    const cssPath = moduleOptions.cssPath && resolveAlias(moduleOptions.cssPath)
+    const cssPath = moduleOptions.cssPath && await resolvePath(moduleOptions.cssPath)
     const injectPosition = ~~Math.min(moduleOptions.injectPosition, (nuxt.options.css || []).length + 1)
 
     // Include CSS file in project css
@@ -49,7 +48,7 @@ export default defineNuxtModule({
         logger.info(`Using Tailwind CSS from ~/${relative(nuxt.options.srcDir, cssPath)}`)
         nuxt.options.css.splice(injectPosition, 0, cssPath)
       } else {
-        logger.info('Using Tailwind CSS from module runtime')
+        logger.info('Using default Tailwind CSS file from runtime/tailwind.css')
         const resolver = createResolver(import.meta.url)
         nuxt.options.css.splice(injectPosition, 0, resolver.resolve('runtime/tailwind.css'))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,6 +297,11 @@
   dependencies:
     mime "^3.0.0"
 
+"@dcrall/tw-test@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcrall/tw-test/-/tw-test-1.0.0.tgz#2850c9c66f902afc8065e87fea9c4894c9fd4477"
+  integrity sha512-/14Zf0DTud9pvGUYTZCN3S8t08lOgfC7qbxViQdvYDL606lgIrXyh4zCNaIMeEMV4nl8QIV3d3joQ/mkVaQqrA==
+
 "@eslint/eslintrc@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"


### PR DESCRIPTION
Test the specification of extensions array in `resolvePath` to resolve a CSS file that does not include the `.css` extension.

```js
  tailwindcss: {
    configPath: '@dcrall/tw-test/tailwind.config.js',
    cssPath: '~/assets/tailwind',
    exposeConfig: true
  },
```

When specifying the extensions, the config above works.

![tw-test-assests-extensions](https://user-images.githubusercontent.com/42922/168642502-a71b3562-f270-4547-8c37-a83461603097.png)

However, when I try to import from an NPM package without the extension, the resolution fails. As the specified path is not seen as part of the package's exports.

```
  tailwindcss: {
    configPath: '@dcrall/tw-test/tailwind.config.js',
    cssPath: '@dcrall/tw-test/tailwind',
    exposeConfig: true
  },
```

```
 ERROR  Cannot restart nuxt:  Package subpath './tailwind' is not defined by "exports" in /Users/dcrall/Projects/tailwindcss-module/node_modules/@dcrall/tw-test/package.json                                                                                                                                 11:45:18

  at new NodeError (node:internal/errors:371:5)
  at throwExportsNotFound (node:internal/modules/esm/resolve:429:9)
  at packageExportsResolve (node:internal/modules/esm/resolve:705:3)
  at resolveExports (node:internal/modules/cjs/loader:482:36)
  at Function.Module._findPath (node:internal/modules/cjs/loader:522:31)
  at Function.Module._resolveFilename (node:internal/modules/cjs/loader:919:27)
  at Function.resolve (node:internal/modules/cjs/helpers:108:19)
  at Function._resolve [as resolve] (node_modules/jiti/dist/jiti.js:1:192841)
  at resolveModule (node_modules/@nuxt/kit/dist/index.mjs:227:41)
  at tryResolveModule (node_modules/@nuxt/kit/dist/index.mjs:233:12)
```